### PR TITLE
Adjustments to MaSyMoS core regarding dynamic ontology import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 		<dependency>
 			<groupId>org.sbml.jsbml</groupId>
 			<artifactId>jsbml</artifactId>
-			<version>1.1-b1</version>
+			<version>1.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>

--- a/src/de/unirostock/sems/masymos/util/OntologyFactory.java
+++ b/src/de/unirostock/sems/masymos/util/OntologyFactory.java
@@ -169,7 +169,16 @@ public class OntologyFactory {
 
 		@Override
 		protected void initialize(Node created, Map<String, Object> properties) {
-			created.setProperty( "id", properties.get( "id" ) );
+			if( properties.containsKey("id") )
+				created.setProperty( "id", properties.get( "id" ) );
+			else if( properties.size() == 1 ) {
+				// does not contain id key, but only one key/value pair use the key as id
+				// This appears to happen, when to COMODI term in question is not yet in the database
+				// (This is a really ugly hack and I've got no idea why this is this way, but whatever)
+				created.setProperty( "id", properties.keySet().toArray()[0]);
+				created.setProperty("dynamicaly_created", true);
+			}
+			
 			created.addLabel( Label.label(this.indexName) );
 		}
 		

--- a/src/de/unirostock/sems/masymos/util/OntologyFactory.java
+++ b/src/de/unirostock/sems/masymos/util/OntologyFactory.java
@@ -164,7 +164,16 @@ public class OntologyFactory {
 
 		@Override
 		protected void initialize(Node created, Map<String, Object> properties) {
-			created.setProperty( "id", properties.get( "id" ) );
+			if( properties.containsKey("id") )
+				created.setProperty( "id", properties.get( "id" ) );
+			else if( properties.size() == 1 ) {
+				// does not contain id key, but only one key/value pair use the key as id
+				// This appears to happen, when to COMODI term in question is not yet in the database
+				// (This is a really ugly hack and I've got no idea why this is this way, but whatever)
+				created.setProperty( "id", properties.keySet().toArray()[0]);
+				created.setProperty("dynamicaly_created", true);
+			}
+			
 			created.addLabel( Label.label(this.indexName) );
 		}
 		

--- a/src/de/unirostock/sems/masymos/util/OntologyFactory.java
+++ b/src/de/unirostock/sems/masymos/util/OntologyFactory.java
@@ -171,13 +171,6 @@ public class OntologyFactory {
 		protected void initialize(Node created, Map<String, Object> properties) {
 			if( properties.containsKey("id") )
 				created.setProperty( "id", properties.get( "id" ) );
-			else if( properties.size() == 1 ) {
-				// does not contain id key, but only one key/value pair use the key as id
-				// This appears to happen, when to COMODI term in question is not yet in the database
-				// (This is a really ugly hack and I've got no idea why this is this way, but whatever)
-				created.setProperty( "id", properties.keySet().toArray()[0]);
-				created.setProperty("dynamicaly_created", true);
-			}
 			
 			created.addLabel( Label.label(this.indexName) );
 		}

--- a/src/de/unirostock/sems/masymos/util/OntologyFactory.java
+++ b/src/de/unirostock/sems/masymos/util/OntologyFactory.java
@@ -166,13 +166,6 @@ public class OntologyFactory {
 		protected void initialize(Node created, Map<String, Object> properties) {
 			if( properties.containsKey("id") )
 				created.setProperty( "id", properties.get( "id" ) );
-			else if( properties.size() == 1 ) {
-				// does not contain id key, but only one key/value pair use the key as id
-				// This appears to happen, when to COMODI term in question is not yet in the database
-				// (This is a really ugly hack and I've got no idea why this is this way, but whatever)
-				created.setProperty( "id", properties.keySet().toArray()[0]);
-				created.setProperty("dynamicaly_created", true);
-			}
 			
 			created.addLabel( Label.label(this.indexName) );
 		}


### PR DESCRIPTION
This pull request will apply the latest bug fixes to the import mechanism for prior unknown ontologies.
The main logic is already incorporated, but it was found that the import fails under certain conditions.
Also the jSBML library was updated to not use the 1.1-beta, but the final 1.1 release.